### PR TITLE
use default app namespace

### DIFF
--- a/i18n/es.po
+++ b/i18n/es.po
@@ -497,7 +497,7 @@ msgid "Invalid output combo"
 msgstr ""
 
 msgid "Scheduler"
-msgstr ""
+msgstr "Programador"
 
 msgid "Last"
 msgstr ""

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1,4 +1,5 @@
 declare module "@dhis2/d2-i18n" {
     export function t(value: string, namespace?: object): string;
     export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
 }

--- a/src/webapp/contexts/app-context.ts
+++ b/src/webapp/contexts/app-context.ts
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { CompositionRoot } from "../../compositionRoot";
 import { User } from "../../domain/entities/User";
 import { D2Api } from "../../types/d2-api";
+import i18n from "../../locales";
 
 export interface AppContextState {
     api: D2Api;
@@ -13,6 +14,7 @@ export const AppContext = React.createContext<AppContextState | null>(null);
 
 export function useAppContext() {
     const context = useContext(AppContext);
+    i18n.setDefaultNamespace("predictor-extended");
     if (context) {
         return context;
     } else {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694ubx3x

### :memo: Implementation
- [x] Update i18n types
- [x] Set default namespace in `app-context.ts`

### :art: Screenshots
<img width="1135" alt="Screenshot 2024-06-25 at 20 04 27" src="https://github.com/EyeSeeTea/predictor-extended-app-dev/assets/37223065/d9cd91b4-6edd-484b-a5c6-c1a31eccd826">

### :fire: Testing
I added a translation for `Scheduler` to test

#8694ubx3x